### PR TITLE
Migrate dictionary merging to ansible native combine filter.

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -84,8 +84,8 @@ pulp_server_config__custom: {}
 
 # Final Pulp Server config
 pulp_server_config: "{{
-  pulp_server_config__default.update(pulp_server_config__custom) }}{{
-  pulp_server_config__default }}"
+  pulp_server_config__default |
+  combine(pulp_server_config__custom) }}"
 
 
 # Pulp Server Plugins configuration
@@ -129,8 +129,8 @@ pulp_workers_config__custom: {}
 
 # Final Pulp Workers config
 pulp_workers_config: "{{
-  pulp_workers_config__default.update(pulp_workers_config__custom) }}{{
-  pulp_workers_config__default }}"
+  pulp_workers_config__default |
+  combine(pulp_workers_config__custom) }}"
 
 
 # Default values of the options of the server section of the Pulp Admin config
@@ -147,8 +147,8 @@ pulp_admin_config_server__custom: {}
 
 # Final server section of the Pulp Admin config
 pulp_admin_config_server: "{{
-  pulp_admin_config_server__default.update(pulp_admin_config_server__custom) }}{{
-  pulp_admin_config_server__default }}"
+  pulp_admin_config_server__default |
+  combine(pulp_admin_config_server__custom) }}"
 
 # Default content of the other section of the Pulp Admin config
 pulp_admin_config_client: {}
@@ -169,8 +169,8 @@ pulp_admin_config__custom: {}
 
 # Final Pulp Admin config
 pulp_admin_config: "{{
-  pulp_admin_config__default.update(pulp_admin_config__custom) }}{{
-  pulp_admin_config__default }}"
+  pulp_admin_config__default |
+  combine (pulp_admin_config__custom) }}"
 
 
 # Default values of the options of the server section of the Pulp Consumer config
@@ -187,8 +187,8 @@ pulp_consumer_config_server__custom: {}
 
 # Final server section of the Pulp Customer config
 pulp_consumer_config_server: "{{
-  pulp_consumer_config_server__default.update(pulp_consumer_config_server__custom) }}{{
-  pulp_consumer_config_server__default }}"
+  pulp_consumer_config_server__default |
+  combine(pulp_consumer_config_server__custom) }}"
 
 # Default content of other sections of the Pulp Consumer config
 pulp_consumer_config_authentication: {}
@@ -217,8 +217,8 @@ pulp_consumer_config__custom: {}
 
 # Final Pulp Customer config
 pulp_consumer_config: "{{
-  pulp_consumer_config__default.update(pulp_consumer_config__custom) }}{{
-  pulp_consumer_config__default }}"
+  pulp_consumer_config__default |
+  combine(pulp_consumer_config__custom) }}"
 
 
 # Default values of the options of the main section of the Pulp repo_auth config
@@ -241,8 +241,8 @@ pulp_repo_auth_config_main__custom: {}
 
 # Final main section of the Pulp repo_auth config
 pulp_repo_auth_config_main: "{{
-  pulp_repo_auth_config_main__default.update(pulp_repo_auth_config_main__custom) }}{{
-  pulp_repo_auth_config_main__default }}"
+  pulp_repo_auth_config_main__default |
+  combine(pulp_repo_auth_config_main__custom) }}"
 
 # Default values of the options of the repos section of the Pulp repo_auth config
 pulp_repo_auth_config_repos_cert_location: /etc/pki/pulp/content
@@ -260,8 +260,8 @@ pulp_repo_auth_config_repos__custom: {}
 
 # Final repos section of the Pulp repo_auth config
 pulp_repo_auth_config_repos: "{{
-  pulp_repo_auth_config_repos__default.update(pulp_repo_auth_config_repos__custom) }}{{
-  pulp_repo_auth_config_repos__default }}"
+  pulp_repo_auth_config_repos__default |
+  combine(pulp_repo_auth_config_repos__custom) }}"
 
 # Default sections of the Pulp repo_auth config
 pulp_repo_auth_config__default:
@@ -273,6 +273,5 @@ pulp_repo_auth_config__custom: {}
 
 # Final Pulp repo_auth config
 pulp_repo_auth_config: "{{
-  pulp_repo_auth_config__default.update(pulp_repo_auth_config__custom) }}{{
-  pulp_repo_auth_config__default }}"
-
+  pulp_repo_auth_config__default |
+  combine(pulp_repo_auth_config__custom) }}"


### PR DESCRIPTION
This seems a bit cleaner to me. The `combine` filter is built into ansible and performs a similar operation to a python `dictionary.update()`. This removes the need to have 2 jinja variable substitutions. 
http://docs.ansible.com/ansible/playbooks_filters.html#combining-hashes-dictionaries