### PR TITLE
Creates RSA keypair

### DIFF
--- a/tasks/pulp_server.yaml
+++ b/tasks/pulp_server.yaml
@@ -76,6 +76,14 @@
   tags:
     - pulp_config
 
+- name: Create Pulp RSA keypair
+  shell: pulp-gen-key-pair
+  notify:
+    - Restart Web Service
+  creates: /etc/pki/pulp/rsa.key
+  tags:
+    - pulp_config
+
 - name: Configure Pulp Workers
   template:
     src: pulp_workers.j2


### PR DESCRIPTION
This is needed for the Django middleware to successfully authenticate to the backend.

This is also part of `/usr/bin/pulp-setup` that isn't being used from this role.